### PR TITLE
Remove deprecated Ruff and Python linting settings

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -34,9 +34,6 @@
       ],
       "settings": {
         "python.defaultInterpreterPath": "/usr/local/bin/python",
-        "python.linting.enabled": true,
-        "python.linting.pylintEnabled": false,
-        "python.formatting.provider": "none",
         "python.analysis.typeCheckingMode": "standard",
         "editor.formatOnSave": true,
         "editor.codeActionsOnSave": {
@@ -46,8 +43,6 @@
           "editor.defaultFormatter": "charliermarsh.ruff",
           "editor.formatOnSave": true
         },
-        "ruff.lint.args": ["--config=pyproject.toml"],
-        "ruff.format.args": ["--config=pyproject.toml"],
         "terminal.integrated.defaultProfile.linux": "zsh"
       }
     }


### PR DESCRIPTION
## Summary

- Remove deprecated `ruff.lint.args` and `ruff.format.args` settings (the new Ruff extension auto-discovers `pyproject.toml`)
- Remove deprecated `python.linting.enabled`, `python.linting.pylintEnabled`, and `python.formatting.provider` settings

Fixes the warning shown when opening in GitHub Codespaces:

> The legacy server (ruff-lsp) has been deprecated. The following settings were only supported by the legacy server and has been deprecated: 'ruff.lint.args', 'ruff.format.args'. Please migrate to the new settings or remove them.