### PR TITLE
Add GitHub Actions workflow for binary builds

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -1,0 +1,73 @@
+name: Build Binaries
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build ${{ matrix.arch }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            arch: x86_64
+          - os: ubuntu-24.04-arm
+            arch: arm64
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install nuitka ordered-set zstandard
+          pip install -e .
+
+      - name: Build binary
+        run: python build_binary.py
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v5
+        with:
+          name: shannot-binary-${{ matrix.arch }}
+          path: dist/shannot-linux-${{ matrix.arch }}
+
+  upload-release:
+    name: Upload to GitHub Release
+    if: github.event_name == 'release' && github.event.action == 'published'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download x86_64 binary
+        uses: actions/download-artifact@v7
+        with:
+          name: shannot-binary-x86_64
+          path: dist/
+
+      - name: Download arm64 binary
+        uses: actions/download-artifact@v7
+        with:
+          name: shannot-binary-arm64
+          path: dist/
+
+      - name: Upload to GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload '${{ github.ref_name }}' dist/* --repo '${{ github.repository }}'


### PR DESCRIPTION
## Summary

- Add new workflow to build Nuitka binaries for Linux on release publish
- Supports both x86_64 and arm64 architectures using native GitHub runners
- Binaries are automatically attached as release assets

## Details

Creates `.github/workflows/build-binary.yml` that:
- Triggers on release publish (and manual dispatch for testing)
- Builds in parallel on `ubuntu-latest` (x86_64) and `ubuntu-24.04-arm` (arm64)
- Uses existing `build_binary.py` script with Nuitka
- Uploads `shannot-linux-x86_64` and `shannot-linux-arm64` to releases

## Test plan

- [ ] Trigger workflow manually via workflow_dispatch to verify builds complete
- [ ] Create a test release to verify binaries are attached as assets