### PR TITLE
Consolidate configuration to single config.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2025-12-25
+
+### Breaking Changes
+
+- Configuration consolidated to single `config.toml` file
+  - Replaces: `profile.json`, `remotes.toml`, `audit.json`
+  - Project-local: `.shannot/config.toml` (for profile and audit)
+  - Global: `~/.config/shannot/config.toml` (for all settings including remotes)
+- Remotes remain global-only (not read from project-local config)
+- `Remote` dataclass no longer has `name` field (name is the dict key)
+
+### Features
+
+- Unified TOML configuration with sections: `[profile]`, `[audit]`, `[remotes.*]`
+- Human-editable config with comments support
+- Consistent precedence: project-local overrides global
+
 ## [0.6.0] - 2025-12-25
 
 ### Features

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ shannot remote test NAME    # Test SSH connection
 shannot status              # Check runtime and pending sessions
 ```
 
-**Key Options:** `--profile PATH`, `--target NAME`, `--dry-run`, `--color/--no-color`
+**Key Options:** `--target NAME`, `--dry-run`, `--color/--no-color`
 
 ## Development Commands
 
@@ -97,10 +97,8 @@ def example(path: Path | str | None = None) -> dict[str, Path]:
 
 | Path | Purpose |
 |------|---------|
-| `~/.config/shannot/profile.json` | Global approval profile |
-| `.shannot/profile.json` | Project approval profile |
-| `~/.config/shannot/remotes.toml` | SSH remote targets |
-| `~/.config/shannot/audit.json` | Audit logging config |
+| `~/.config/shannot/config.toml` | Global configuration (profile, audit, remotes) |
+| `.shannot/config.toml` | Project configuration (takes precedence) |
 | `~/.local/share/shannot/runtime/` | PyPy stdlib |
 | `~/.local/share/shannot/sessions/` | Session data |
 | `~/.local/share/shannot/audit/` | Audit logs (JSONL) |

--- a/README.md
+++ b/README.md
@@ -229,26 +229,26 @@ shannot status
 
 ## Configuration
 
-Shannot uses command approval profiles to control subprocess execution behavior:
+All settings are in a single TOML file:
 
-- **Auto-approve list** - Commands like `ls`, `cat`, `grep` execute immediately
-- **Always deny list** - Dangerous commands like `rm -rf /` are blocked
-- **Profile locations**:
-  - Project-local: `.shannot/profile.json`
-  - Global: `~/.config/shannot/profile.json`
+- **Project-local**: `.shannot/config.toml` (takes precedence)
+- **Global**: `~/.config/shannot/config.toml`
 
-Example profile:
+Example config:
 
-```json
-{
-  "auto_approve": [
-    "cat", "ls", "find", "grep", "head", "tail"
-  ],
-  "always_deny": [
-    "rm -rf /",
-    "dd if=/dev/zero"
-  ]
-}
+```toml
+[profile]
+auto_approve = ["cat", "ls", "find", "grep", "head", "tail"]
+always_deny = ["rm -rf /", "dd if=/dev/zero"]
+
+[audit]
+enabled = true
+rotation = "daily"
+max_files = 30
+
+[remotes.prod]
+host = "prod.example.com"
+user = "admin"
 ```
 
 ## Security Considerations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "shannot"
-version = "0.6.0"
+version = "0.7.0"
 description = "Sandboxed system administration for LLM agents"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/shannot/mix_subprocess.py
+++ b/shannot/mix_subprocess.py
@@ -25,9 +25,9 @@ class MixSubprocess:
         4. Everything else: queue for review
 
     Profile-based configuration:
-        - .shannot/profile.json (project-local, takes precedence)
-        - ~/.config/shannot/profile.json (global fallback)
-        - DEFAULT_PROFILE if no file exists
+        - .shannot/config.toml (project-local, takes precedence)
+        - ~/.config/shannot/config.toml (global fallback)
+        - Built-in defaults if no config file exists
 
     Modes:
         subprocess_dry_run: bool - log all, execute none
@@ -241,11 +241,11 @@ class MixSubprocess:
 
     def load_profile(self):
         """Load security profile into class attributes."""
-        from .config import load_profile
+        from .config import load_config
 
-        profile = load_profile()
-        self.subprocess_auto_approve.update(profile.get("auto_approve", []))
-        self.subprocess_always_deny.update(profile.get("always_deny", []))
+        profile = load_config().profile
+        self.subprocess_auto_approve.update(profile.auto_approve)
+        self.subprocess_always_deny.update(profile.always_deny)
 
     def save_pending(self):
         """Write pending commands to queue file."""

--- a/test/test_remote_config.py
+++ b/test/test_remote_config.py
@@ -8,12 +8,13 @@ from unittest import mock
 import pytest
 
 from shannot.config import (
+    Config,
     Remote,
     add_remote,
     load_remotes,
     remove_remote,
     resolve_target,
-    save_remotes,
+    save_config,
 )
 
 
@@ -21,20 +22,16 @@ class TestRemote:
     """Tests for Remote dataclass."""
 
     def test_target_string(self):
-        r = Remote(name="prod", host="example.com", user="admin", port=22)
+        r = Remote(host="example.com", user="admin", port=22)
         assert r.target_string == "admin@example.com"
 
-    def test_to_dict(self):
-        r = Remote(name="prod", host="example.com", user="admin", port=2222)
-        assert r.to_dict() == {"host": "example.com", "user": "admin", "port": 2222}
-
     def test_default_port(self):
-        r = Remote(name="prod", host="example.com", user="admin")
+        r = Remote(host="example.com", user="admin")
         assert r.port == 22
 
 
 class TestRemotesConfig:
-    """Tests for remotes.toml file operations."""
+    """Tests for config.toml file operations."""
 
     def setup_method(self):
         """Create temp config directory."""
@@ -54,11 +51,12 @@ class TestRemotesConfig:
 
     def test_save_and_load(self):
         """Round-trip save and load."""
-        remotes = {
-            "prod": Remote(name="prod", host="prod.example.com", user="admin", port=22),
-            "staging": Remote(name="staging", host="staging.example.com", user="deploy", port=2222),
+        config = Config()
+        config.remotes = {
+            "prod": Remote(host="prod.example.com", user="admin", port=22),
+            "staging": Remote(host="staging.example.com", user="deploy", port=2222),
         }
-        save_remotes(remotes)
+        save_config(config)
         loaded = load_remotes()
 
         assert len(loaded) == 2
@@ -71,7 +69,6 @@ class TestRemotesConfig:
         """Adding a remote persists it."""
         remote = add_remote("prod", "prod.example.com", user="admin")
 
-        assert remote.name == "prod"
         assert remote.host == "prod.example.com"
         assert remote.user == "admin"
         assert remote.port == 22

--- a/uv.lock
+++ b/uv.lock
@@ -793,7 +793,7 @@ wheels = [
 
 [[package]]
 name = "shannot"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Replace profile.json, remotes.toml, and audit.json with unified config.toml file using TOML format for human-editability.

Config structure:
- [profile] - auto_approve and always_deny command lists
- [audit] - audit logging settings
- [remotes.*] - SSH remote targets

Precedence:
- Profile/audit: project-local (.shannot/config.toml) > global
- Remotes: global only (~/.config/shannot/config.toml)

Breaking changes:
- Remote dataclass no longer has 'name' field (name is dict key)
- Old config files are no longer read

Bumps version to 0.7.0.