### PR TITLE
Fix arrow keys in approval TUI for Ghostty and similar terminals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1] - 2025-12-25
+
+### Bug Fixes
+
+- Fix arrow keys not working reliably in approval TUI on some terminals (Ghostty)
+  - Use `os.read()` instead of `sys.stdin.read()` to bypass Python's buffered I/O
+
 ## [0.7.0] - 2025-12-25
 
 ### Breaking Changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "shannot"
-version = "0.7.0"
+version = "0.7.1"
 description = "Sandboxed system administration for LLM agents"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/uv.lock
+++ b/uv.lock
@@ -793,7 +793,7 @@ wheels = [
 
 [[package]]
 name = "shannot"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Use os.read() instead of sys.stdin.read() to bypass Python's buffered I/O layer, which was causing escape sequences to be split across multiple reads on some terminals.